### PR TITLE
Feature/signup

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,6 +1,6 @@
 {
   "expo": {
-    "name": "02-nativeapp",
+    "name": "一流レシピ",
     "slug": "02-nativeapp",
     "scheme": "jp.qin.recipe.02-nativeapp",
     "version": "1.0.0",
@@ -21,7 +21,7 @@
         "foregroundImage": "./assets/logo/IchiryuRecipe_Favicon_256×256px.png",
         "backgroundColor": "#ffffff"
       },
-      "package": "host.exp.exponent"
+      "package": "jp.qin.recipe"
     },
     "web": {
       "favicon": "./assets/logo/IchiryuRecipe_Favicon_32×32px.png"
@@ -32,6 +32,9 @@
         "androidClientId": "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
         "iosClientId": "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
         "expoClientId": "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+      },
+      "eas": {
+        "projectId": "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
       }
     }
   }

--- a/eas.json
+++ b/eas.json
@@ -1,0 +1,31 @@
+{
+  "cli": {
+    "version": ">= 3.5.2"
+  },
+  "build": {
+    "development": {
+      "developmentClient": true,
+      "distribution": "internal",
+      "ios": {
+        "resourceClass": "m1-medium"
+      },
+      "android": { "buildType": "apk" }
+    },
+    "preview": {
+      "distribution": "internal",
+      "ios": {
+        "resourceClass": "m1-medium"
+      },
+      "android": { "buildType": "apk" }
+    },
+    "production": {
+      "ios": {
+        "resourceClass": "m1-medium"
+      },
+      "android": { "buildType": "apk" }
+    }
+  },
+  "submit": {
+    "production": {}
+  }
+}

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "expo-auth-session": "~4.0.3",
     "expo-camera": "~13.2.1",
     "expo-constants": "~14.2.1",
+    "expo-dev-client": "~2.2.1",
     "expo-image-picker": "~14.1.1",
     "expo-linear-gradient": "~12.1.2",
     "expo-status-bar": "~1.4.4",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "native-base": "^3.4.28",
     "react": "18.2.0",
     "react-dom": "^18.2.0",
+    "react-hook-form": "^7.46.1",
     "react-native": "0.71.8",
     "react-native-modal": "^13.0.1",
     "react-native-pager-view": "^6.2.1",

--- a/src/components/Button/ActionButton.tsx
+++ b/src/components/Button/ActionButton.tsx
@@ -1,0 +1,70 @@
+import React from "react"
+import {
+  TouchableOpacity,
+  Text,
+  StyleSheet,
+  TouchableOpacityProps,
+} from "react-native"
+
+export type ActionButtonProps = TouchableOpacityProps & {
+  title: string
+  theme: "filled" | "outline"
+  color?: "tomato" | "gray"
+  size?: "sm" | "lg"
+  onPress: () => void
+}
+
+export const ActionButton: React.FC<ActionButtonProps> = (props) => {
+  const buttonStyle = [
+    styles.button,
+    styles[props.theme ?? "filled"],
+    styles[props.color ?? "tomato"],
+    styles[props.size ?? "sm"],
+  ]
+
+  return (
+    <TouchableOpacity style={buttonStyle} onPress={props.onPress}>
+      <Text
+        style={{
+          color: props.theme === "filled" ? "white" : "tomato",
+          textAlign: "center",
+        }}
+      >
+        {props.title}
+      </Text>
+    </TouchableOpacity>
+  )
+}
+
+const styles = StyleSheet.create({
+  button: {
+    borderRadius: 4,
+    padding: 10,
+    textAlign: "center",
+    width: "100%",
+  },
+  filled: {
+    color: "white",
+    borderWidth: 0,
+    backgroundColor: "tomato",
+  },
+  outline: {
+    backgroundColor: "transparent",
+    borderColor: "tomato",
+    borderWidth: 1,
+  },
+  gray: {
+    borderColor: "gray",
+  },
+  tomato: {
+    borderColor: "tomato",
+  },
+  sm: {
+    height: 40,
+    fontSize: 14,
+  },
+  lg: {
+    height: 50,
+    fontSize: 18,
+  },
+})

--- a/src/components/Label/MainHeader.tsx
+++ b/src/components/Label/MainHeader.tsx
@@ -19,23 +19,22 @@ export const MainHeader: React.FC<MainHeaderProps> = (props) => {
   let leftItem: JSX.Element | undefined = undefined
   if (props.leftItem === "setting") {
     leftItem = (
-      <TouchableOpacity onPress={() => onPressSetting}>
-        <Icon as={<Ionicons name="menu" />} size="5" ml="2" color="black" />
+      <TouchableOpacity onPress={() => onPressSetting()}>
+        <Icon as={<Ionicons name="menu" />} size="5" color="black" />
       </TouchableOpacity>
     )
   } else if (props.leftItem === "pageback") {
     leftItem = <PageBackButton />
   }
   const onPressSetting = () => {
-    console.log("setting")
-    //navigation.navigate("Setting", {})
+    navigation.navigate("Setting", {})
   }
 
   // 右アイテム
   let rightItem: JSX.Element | undefined = undefined
   if (props.rightItem === "mypage") {
     rightItem = (
-      <TouchableOpacity onPress={() => onPressMyPage}>
+      <TouchableOpacity onPress={() => onPressMyPage()}>
         <Icon
           as={<FontAwesome name="user-circle-o" />}
           size="5"

--- a/src/components/Label/MainHeader.tsx
+++ b/src/components/Label/MainHeader.tsx
@@ -1,0 +1,76 @@
+import { Ionicons, FontAwesome } from "@expo/vector-icons"
+import { useNavigation } from "@react-navigation/native"
+import { HStack, Icon, Text, View } from "native-base"
+import React from "react"
+import { TouchableOpacity } from "react-native"
+
+import { PageBackButton } from "../Button"
+
+export type MainHeaderProps = {
+  title: string
+  leftItem?: "setting" | "pageback"
+  rightItem?: "mypage"
+}
+
+export const MainHeader: React.FC<MainHeaderProps> = (props) => {
+  const navigation = useNavigation<any>()
+
+  // 左アイテム
+  let leftItem: JSX.Element | undefined = undefined
+  if (props.leftItem === "setting") {
+    leftItem = (
+      <TouchableOpacity onPress={() => onPressSetting}>
+        <Icon as={<Ionicons name="menu" />} size="5" ml="2" color="black" />
+      </TouchableOpacity>
+    )
+  } else if (props.leftItem === "pageback") {
+    leftItem = <PageBackButton />
+  }
+  const onPressSetting = () => {
+    console.log("setting")
+    //navigation.navigate("Setting", {})
+  }
+
+  // 右アイテム
+  let rightItem: JSX.Element | undefined = undefined
+  if (props.rightItem === "mypage") {
+    rightItem = (
+      <TouchableOpacity onPress={() => onPressMyPage}>
+        <Icon
+          as={<FontAwesome name="user-circle-o" />}
+          size="5"
+          ml="2"
+          color="black"
+        />
+      </TouchableOpacity>
+    )
+  }
+  const onPressMyPage = () => {
+    console.log("mypage")
+    //navigation.navigate("MyPage", {})
+  }
+
+  return (
+    <HStack
+      justifyContent="space-between"
+      backgroundColor="white"
+      alignItems="center"
+      h={12}
+      mb={2}
+      w="full"
+      shadow="2"
+    >
+      <View flex={0.2} justifyContent="flex-start" alignItems="center">
+        {leftItem}
+      </View>
+      <View flex={0.6} justifyContent="center" alignItems="center">
+        <Text fontWeight="bold" fontSize="xl">
+          {props.title}
+        </Text>
+      </View>
+      <View flex={0.2} justifyContent="flex-end" alignItems="center">
+        {rightItem}
+      </View>
+    </HStack>
+  )
+}

--- a/src/components/Label/index.tsx
+++ b/src/components/Label/index.tsx
@@ -1,2 +1,3 @@
 export { FavoriteCount } from "./FavoriteCount"
 export { SubHeader } from "./SubHeader"
+export { MainHeader } from "./MainHeader"

--- a/src/components/Tab/TabContainer.tsx
+++ b/src/components/Tab/TabContainer.tsx
@@ -80,7 +80,8 @@ export const TabContainer: React.FC<TabContainerProps> = ({
       // 高さを一度も計算していなければ計算して保持する
       if (heights[index] === 0 && containerHeight !== 0) {
         const newHeights = [...heights]
-        newHeights[index] = containerHeight
+        newHeights[index] =
+          containerHeight > windowHeight ? containerHeight : windowHeight
         setHeights(newHeights)
       }
     },

--- a/src/libs/APIFetch/index.tsx
+++ b/src/libs/APIFetch/index.tsx
@@ -38,4 +38,5 @@ export {
   Ingredient,
   Link,
   ChefRecipe,
+  GoogleUser,
 } from "./type"

--- a/src/libs/APIFetch/type.ts
+++ b/src/libs/APIFetch/type.ts
@@ -71,3 +71,10 @@ export type ChefRecipe = {
   recipe_id: number
   recipe: Recipe
 }
+
+export type GoogleUser = {
+  display_name: string
+  email: string
+  service_name: string
+  service_user_id: string
+}

--- a/src/routing/FavoriteStacks.tsx
+++ b/src/routing/FavoriteStacks.tsx
@@ -9,7 +9,7 @@ const Stack = createNativeStackNavigator()
 export const FavoriteStacks: React.FC = () => {
   const { isAuthenticated } = useAuth()
   return (
-    <Stack.Navigator>
+    <Stack.Navigator screenOptions={{ headerShown: false }}>
       {isAuthenticated ? (
         <Stack.Screen name="Favorite" component={FavoriteScreen} />
       ) : (

--- a/src/routing/RootStackNavigator.tsx
+++ b/src/routing/RootStackNavigator.tsx
@@ -3,7 +3,8 @@ import { createNativeStackNavigator } from "@react-navigation/native-stack"
 import { TabNavigator } from "./TabNavigator"
 import { ChefsScreen } from "../screens/chefs"
 import { RecipesScreen } from "../screens/recipes"
-import { SignupScreen } from "../screens/signup/screen"
+import { SettingScreen } from "../screens/setting"
+import { SignupScreen } from "../screens/signup"
 
 const Stack = createNativeStackNavigator()
 
@@ -14,6 +15,7 @@ export const RootStackNavigator: React.FC = () => {
       <Stack.Screen name="Chefs" component={ChefsScreen} />
       <Stack.Screen name="Recipes" component={RecipesScreen} />
       <Stack.Screen name="Signup" component={SignupScreen} />
+      <Stack.Screen name="Setting" component={SettingScreen} />
     </Stack.Navigator>
   )
 }

--- a/src/routing/RootStackParamList.ts
+++ b/src/routing/RootStackParamList.ts
@@ -19,6 +19,7 @@ export type RootStackParamList = {
   Signup: {
     googleUser: GoogleUser
   }
+  Setting: object
 }
 
 export type SearchStackParamList = {

--- a/src/routing/RootStackParamList.ts
+++ b/src/routing/RootStackParamList.ts
@@ -1,6 +1,6 @@
 import { NavigationProp } from "@react-navigation/native"
 
-import { Chef, Recipe } from "../libs/APIFetch/"
+import { Chef, GoogleUser, Recipe } from "../libs/APIFetch/"
 
 export type StackNavigation = NavigationProp<
   RootStackParamList | SearchStackParamList
@@ -15,6 +15,9 @@ export type RootStackParamList = {
   }
   Signin: {
     sourceScreen: string
+  }
+  Signup: {
+    googleUser: GoogleUser
   }
 }
 

--- a/src/routing/ShoppingListStacks.tsx
+++ b/src/routing/ShoppingListStacks.tsx
@@ -9,7 +9,7 @@ const Stack = createNativeStackNavigator()
 export const ShoppingListStacks: React.FC = () => {
   const { isAuthenticated } = useAuth()
   return (
-    <Stack.Navigator>
+    <Stack.Navigator screenOptions={{ headerShown: false }}>
       {isAuthenticated ? (
         <Stack.Screen name="ShoppingList" component={ShoppingListScreen} />
       ) : (

--- a/src/screens/favorites/screen.tsx
+++ b/src/screens/favorites/screen.tsx
@@ -1,17 +1,44 @@
-import { View, Text, Button } from "native-base"
+import { Stack, VStack, Text, Box } from "native-base"
+import React from "react"
 
-import { useAuth } from "../../components/Auth"
+import { MainHeader, SubHeader } from "../../components/Label"
+import { ViewContainer } from "../../components/layout"
 
 export const FavoriteScreen: React.FC = () => {
-  const { signout } = useAuth()
-
-  const handleSignout = () => {
-    signout()
-  }
   return (
-    <View style={{ flex: 1, alignItems: "center", justifyContent: "center" }}>
-      <Text>Favorite Screen</Text>
-      <Button onPress={handleSignout}>ログアウト</Button>
-    </View>
+    <ViewContainer>
+      <MainHeader title="お気に入り" leftItem="setting" rightItem="mypage" />
+      <Stack space={12} mb={4}>
+        {/* シェフ */}
+        <VStack space={2}>
+          <SubHeader title="シェフ"></SubHeader>
+          <Box m={2}>
+            <Text>データがありません</Text>
+          </Box>
+        </VStack>
+
+        {/* 新着レシピ */}
+        <VStack space={2}>
+          <SubHeader
+            title="新着レシピ"
+            link={{ href: "/favorites", text: "もっと見る" }}
+          ></SubHeader>
+          <Box m={2}>
+            <Text>データがありません</Text>
+          </Box>
+        </VStack>
+
+        {/* お気に入りレシピ */}
+        <VStack space={2}>
+          <SubHeader
+            title="お気に入りレシピ"
+            link={{ href: "/favorites", text: "もっと見る" }}
+          ></SubHeader>
+          <Box m={2}>
+            <Text>データがありません</Text>
+          </Box>
+        </VStack>
+      </Stack>
+    </ViewContainer>
   )
 }

--- a/src/screens/setting/components/SettingItem.tsx
+++ b/src/screens/setting/components/SettingItem.tsx
@@ -1,0 +1,33 @@
+import {
+  MaterialIcons,
+  MaterialCommunityIcons,
+  Feather,
+} from "@expo/vector-icons"
+import { Box, HStack, Icon, Text } from "native-base"
+
+export const SettingItem: React.FC<{
+  title: string
+  icon?: "movepage" | "link" | "logout" | "deleteaccount"
+}> = (props) => {
+  let rightIcon = <></>
+  if (props.icon) {
+    if (props.icon === "movepage") {
+      rightIcon = <MaterialIcons name="keyboard-arrow-right" />
+    } else if (props.icon === "link") {
+      rightIcon = <MaterialCommunityIcons name="arrow-top-right" />
+    } else if (props.icon === "logout") {
+      rightIcon = <MaterialIcons name="logout" />
+    } else if (props.icon === "deleteaccount") {
+      rightIcon = <Feather name="info" />
+    }
+  }
+
+  return (
+    <Box m={2}>
+      <HStack>
+        <Text ml={2}>{props.title}</Text>
+        <Icon as={rightIcon} size="6" ml="auto" color="black" />
+      </HStack>
+    </Box>
+  )
+}

--- a/src/screens/setting/components/index.ts
+++ b/src/screens/setting/components/index.ts
@@ -1,0 +1,1 @@
+export { SettingItem } from "./SettingItem"

--- a/src/screens/setting/index.ts
+++ b/src/screens/setting/index.ts
@@ -1,0 +1,1 @@
+export { SettingScreen } from "./screen"

--- a/src/screens/setting/screen.tsx
+++ b/src/screens/setting/screen.tsx
@@ -1,0 +1,80 @@
+import { useNavigation } from "@react-navigation/native"
+import { Text, VStack, HStack, Modal, View, Center, Box } from "native-base"
+import React, { useState } from "react"
+import { Pressable } from "react-native"
+
+import { SettingItem } from "./components"
+import { useAuth } from "../../components/Auth"
+import { ActionButton } from "../../components/Button/ActionButton"
+import { MainHeader, SubHeader } from "../../components/Label"
+import { ViewContainer } from "../../components/layout"
+
+export const SettingScreen: React.FC = () => {
+  const { isAuthenticated, signout } = useAuth()
+  const [showModal, setShowModal] = useState(false)
+  const navigation = useNavigation<any>()
+
+  const closeModal = () => setShowModal(false)
+  const handleOnPressSignout = () => {
+    setShowModal(true)
+  }
+  const handleSignout = () => {
+    signout()
+    navigation.navigate("Index", { screen: "Favorite" })
+  }
+
+  return (
+    <ViewContainer>
+      <MainHeader title="設定" leftItem="pageback" />
+      <VStack space={2}>
+        <View mt={2} />
+        <SubHeader title="利用規約や問い合わせ"></SubHeader>
+        <SettingItem title="利用規約" icon="movepage" />
+        <SettingItem title="プライバシーポリシー" icon="movepage" />
+        <SettingItem title="運営会社" icon="link" />
+        <SettingItem title="お問い合わせ" icon="link" />
+
+        {isAuthenticated && (
+          <>
+            <View mt={2} />
+            <SubHeader title="アカウント操作"></SubHeader>
+            <Pressable onPress={handleOnPressSignout}>
+              <SettingItem title="ログアウト" icon="logout" />
+            </Pressable>
+
+            <View mt={2} />
+            <SubHeader title="取り消しができる操作"></SubHeader>
+            <SettingItem title="退会する" icon="deleteaccount" />
+          </>
+        )}
+      </VStack>
+
+      {/* 確認ダイアログ */}
+      <Modal isOpen={showModal} onClose={closeModal}>
+        <Box backgroundColor="white" rounded="sm">
+          <Center m={2}>
+            <Text m={2}>ログアウトしますか？</Text>
+            <Box w="48">
+              <HStack>
+                <View flex={0.5} m={2}>
+                  <ActionButton
+                    onPress={handleSignout}
+                    theme="filled"
+                    title="はい"
+                  />
+                </View>
+                <View flex={0.5} m={2}>
+                  <ActionButton
+                    onPress={closeModal}
+                    theme="outline"
+                    title="いいえ"
+                  />
+                </View>
+              </HStack>
+            </Box>
+          </Center>
+        </Box>
+      </Modal>
+    </ViewContainer>
+  )
+}

--- a/src/screens/shopping-list/screen.tsx
+++ b/src/screens/shopping-list/screen.tsx
@@ -1,17 +1,45 @@
-import { View, Text, Button } from "native-base"
+import { MaterialCommunityIcons } from "@expo/vector-icons"
+import { Box, Checkbox, HStack, Icon, VStack, View, Text } from "native-base"
+import React, { useState } from "react"
 
-import { useAuth } from "../../components/Auth"
+import { MainHeader, SubHeader } from "../../components/Label"
+import { ViewContainer } from "../../components/layout"
 
 export const ShoppingListScreen: React.FC = () => {
-  const { signout } = useAuth()
+  const [shoppingList] = useState<string[]>(["だしの素", "みりん"])
 
-  const handleSignout = () => {
-    signout()
-  }
   return (
-    <View style={{ flex: 1, alignItems: "center", justifyContent: "center" }}>
-      <Text>ShoppingList Screen</Text>
-      <Button onPress={handleSignout}>ログアウト</Button>
-    </View>
+    <ViewContainer>
+      <MainHeader title="買い物リスト" />
+      <VStack space={2}>
+        <View mt={2} />
+        <SubHeader title="自分のメモ"></SubHeader>
+        {shoppingList.map((value, index) => (
+          <Box
+            key={index}
+            borderStyle="solid"
+            borderWidth={1}
+            borderColor="gray.300"
+            mb={0}
+          >
+            <HStack minH={12} alignItems="center">
+              <Checkbox
+                rounded="full"
+                value=""
+                ml={2}
+                accessibilityLabel="checkbox"
+              />
+              <Text ml={2}>{value}</Text>
+              <Icon
+                as={<MaterialCommunityIcons name="dots-vertical" />}
+                size="6"
+                ml="auto"
+                color="black"
+              />
+            </HStack>
+          </Box>
+        ))}
+      </VStack>
+    </ViewContainer>
   )
 }

--- a/src/screens/signin/screen.tsx
+++ b/src/screens/signin/screen.tsx
@@ -119,7 +119,10 @@ export const SigninScreen: React.FC = () => {
   const isFavoraitePage = route.params.sourceScreen === "Favorite"
   return (
     <ViewContainer>
-      <MainHeader title={isFavoraitePage ? "お気に入り" : "買い物リスト"} />
+      <MainHeader
+        title={isFavoraitePage ? "お気に入り" : "買い物リスト"}
+        leftItem="setting"
+      />
       <VStack flex={1} alignItems="center">
         <Image
           source={isFavoraitePage ? favoriteImage : shoppingListImage}
@@ -141,14 +144,18 @@ export const SigninScreen: React.FC = () => {
           >
             <HStack>
               <Icon as={<AntDesign name="google" />} size="5" color="white" />
-              <Text color="white">Googleログイン</Text>
+              <Text color="white" ml={1}>
+                Googleログイン
+              </Text>
             </HStack>
           </Button>
           <View m="2"></View>
           <Button backgroundColor="black" disabled>
             <HStack>
               <Icon as={<AntDesign name="apple1" />} size="5" color="white" />
-              <Text color="white">Appleログイン</Text>
+              <Text color="white" ml={1}>
+                Appleログイン
+              </Text>
             </HStack>
           </Button>
         </HStack>

--- a/src/screens/signup/screen.tsx
+++ b/src/screens/signup/screen.tsx
@@ -1,9 +1,142 @@
-import { View, Text } from "native-base"
+import { RouteProp, useNavigation, useRoute } from "@react-navigation/native"
+import { View, Text, VStack, HStack, Input, Button, Modal } from "native-base"
+import React, { useEffect, useState } from "react"
+import { useForm, Controller } from "react-hook-form"
+
+import { useAuth } from "../../components/Auth"
+import { ActionButton } from "../../components/Button/ActionButton"
+import { SubHeader, MainHeader } from "../../components/Label"
+import { ViewContainer } from "../../components/layout"
+import { API_URL } from "../../constants"
+import { GoogleUser } from "../../libs/APIFetch"
+import { RootStackParamList } from "../../routing"
 
 export const SignupScreen: React.FC = () => {
+  const route = useRoute<RouteProp<RootStackParamList, "Signup">>()
+  const [showModal, setShowModal] = useState(false)
+  const { signin, signout } = useAuth()
+  const {
+    control,
+    handleSubmit,
+    formState: { errors },
+    setValue,
+  } = useForm()
+  const navigation = useNavigation<any>()
+
+  useEffect(() => {
+    setValue("nickName", route.params?.googleUser?.display_name ?? "")
+  }, [route])
+
+  /**
+   * サブミット
+   */
+  const onSubmit = (data: any) => {
+    const newGoogleUser: GoogleUser = {
+      ...route.params?.googleUser,
+      display_name: data.nickName,
+    }
+    tryRegister(newGoogleUser)
+  }
+
+  /**
+   * 新規登録
+   */
+  const tryRegister = async (googleUser: GoogleUser) => {
+    try {
+      const response = await fetch(`${API_URL}/register`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(googleUser),
+      })
+      const result = await response.json()
+      if (result?.message === "success" && result?.data?.token) {
+        // 登録成功
+        await signin(result?.data?.token)
+        navigation.navigate("Index", { screen: "Favorite" })
+      } else {
+        // 失敗
+        setShowModal(true)
+      }
+    } catch (error) {
+      console.log("tryRegister error=" + JSON.stringify(error))
+      setShowModal(true)
+    }
+  }
+  /**
+   * キャンセル
+   */
+  const onCancel = () => {
+    signout()
+    navigation.navigate("Index", { screen: "Favorite" })
+  }
+  /**
+   * ダイアログクローズ
+   */
+  const closeModal = () => setShowModal(false)
+
   return (
-    <View style={{ flex: 1, alignItems: "center", justifyContent: "center" }}>
-      <Text>Sign Up</Text>
-    </View>
+    <ViewContainer>
+      <MainHeader title="新規登録" />
+
+      <View
+        flex={1}
+        justifyContent="space-between"
+        alignItems="center"
+        w="full"
+      >
+        <VStack space={2} w="full">
+          <SubHeader title="ニックネーム"></SubHeader>
+          <Controller
+            control={control}
+            rules={{
+              required: true,
+            }}
+            render={({ field: { onChange, onBlur, value } }) => (
+              <Input
+                type="text"
+                placeholder="ニックネーム"
+                onBlur={onBlur}
+                onChangeText={onChange}
+                value={value}
+                backgroundColor="gray.200"
+                borderColor="gray.300"
+                maxLength={20}
+              />
+            )}
+            name="nickName"
+          />
+          {errors.nickName && <Text color="red.600">必須項目です</Text>}
+
+          <HStack justifyContent="space-between" alignItems="center" w="full">
+            <View flex={0.5} m={2}>
+              <ActionButton
+                onPress={handleSubmit(onSubmit)}
+                theme="filled"
+                title="登録"
+              />
+            </View>
+            <View flex={0.5} m={2}>
+              <ActionButton
+                onPress={() => onCancel()}
+                theme="outline"
+                title="キャンセル"
+              />
+            </View>
+          </HStack>
+        </VStack>
+      </View>
+
+      {/* エラー表示 */}
+      <Modal isOpen={showModal} onClose={closeModal}>
+        <View
+          style={{ flex: 1, justifyContent: "center", alignItems: "center" }}
+        >
+          <Text>新規登録に失敗しました</Text>
+          <Button onPress={closeModal}>
+            <Text>閉じる</Text>
+          </Button>
+        </View>
+      </Modal>
+    </ViewContainer>
   )
 }


### PR DESCRIPTION
## 概要
・新規登録画面を追加
・設定画面を追加（ログアウト機能のみ実装）
・expo-auth-sessionでuseProxyが非推奨になった件に伴い、ExpoGoでなく開発ビルドをする前提に設定を変更

## 開発ビルドについて
ExpoGoの上でアプリを動かすのでなく、エミュレータもしくは実機に開発ビルド資材をインストールしてアプリを動かします。
[公式ドキュメント](https://docs.expo.dev/develop/development-builds/introduction/#what-is-expo-dev-client)

ExpoGoの場合、SSO認証機能ではauth.expo.ioを利用してExpoGoへリダイレクトするように設定されていましたが、これがセキュリティ上の問題からExpo48で非推奨になり、かつExpo49では廃止されました。
公式でも開発ビルドへ移行するように訴えられています。
[公式ドキュメント](https://blog.expo.dev/security-advisory-for-developers-using-authsessions-useproxy-options-and-auth-expo-io-e470fe9346df)

このプルリクの前までは、app.jsonで指定しているpackageはExpoGoを示す「host.exp.exponent」でしたが、インストールするためにオリジナルの名前「jp.qin.recipe」に変更しました。（もしExpoGoに戻したい場合は、これをもとに戻してください。）
GCP側の設定は、ExpoClient用のウェブアプリケーションクライアントIDとは別に、開発ビルドではandroidクライアントIDが必要になります。パッケージ名は合わせてください。

例）
![image](https://github.com/qin-team-recipe/02-nativeapp/assets/5800064/9fa081e6-4c6c-471a-837d-0f452d9e7127)


## 動画

https://github.com/qin-team-recipe/02-nativeapp/assets/5800064/25262509-2507-41de-b15b-d0f70724d189

